### PR TITLE
Use execution_date macro and convert to datetime using new tz.

### DIFF
--- a/AIRFLOW-4128/test_bash_template_dag.py
+++ b/AIRFLOW-4128/test_bash_template_dag.py
@@ -19,12 +19,8 @@ def print_the_new_timezone(**context):
     print("execution_date in ISO Format: {}".format(execution_date))
 
     # Convert UTC execution date to US/Pacific
-    utc_tz = dateutil.tz.gettz('UTC')
-    to_zone = dateutil.tz.gettz('US/Pacific')
-    utc_object = datetime.strptime(execution_date, '%Y-%m-%dT%H:%M:%S.%f+00:00')
-    new_utc_object = utc_object.replace(tzinfo=utc_tz)
-    converted_datetime = new_utc_object.astimezone(to_zone)
-
+    local_tz = pendulum.timezone("US/Pacific")
+    new_datetime_object = local_tz.convert(execution_date)
     print("Converted datetime: {}".format(converted_datetime))
 
 local_tz = pendulum.timezone("US/Pacific")


### PR DESCRIPTION
Summary: 
[Timezone readme](https://github.com/apache/airflow/blob/ddec6bbeb34bb3db5919a0dc87dd084552c54bef/docs/timezone.rst#templates) provides recommendation on how to convert execution_date to a specific timezone. 

JIRA Story: 
https://issues.apache.org/jira/browse/AIRFLOW-4128

Reviewer:
Jose Escobar